### PR TITLE
security-release-process: nominate Joel Smith as full time member

### DIFF
--- a/security-release-process.md
+++ b/security-release-process.md
@@ -76,12 +76,12 @@ The initial Product Security Committee will consist of volunteers subscribed to 
 - CJ Cullen (**[@cjcullen](https://github.com/cjcullen)**) `<cjcullen@google.com>`
 - Tim Allclair (**[@tallclair](https://github.com/tallclair)**) `<tallclair@google.com>` [4096R/0x5E6F2E2DA760AF51]
 - Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) `<jordan@liggitt.net>` [4096R/0x39928704103C7229]
+- Joel Smith (**[@joelsmith](https://github.com/joelsmith)**) `<joelsmith@redhat.com>`
 
 [Associate](#Associate) members include:
 
 - Micah Hausler (**[@micahhausler](https://github.com/micahhausler)**) `<mhausler@amazon.com>`
 - Jonathan Pulsifer (**[@jonpulsifer](https://github.com/jonpulsifer)**) `<jonathan@pulsifer.ca>`
-- Joel Smith (**[@joelsmith](https://github.com/joelsmith)**) `<joelsmith@redhat.com>`
 
 ### Contacting the Team
 


### PR DESCRIPTION
Nomination email sent to kubernetes-security-discuss

https://groups.google.com/forum/#!forum/kubernetes-security-discuss

I want to nominate Joel Smith to join the Product Security Committee as
a full member. He has been an associate member since December 4th 2018
and in that role over the last three months he has helped on a number of
tasks including:

- Evaluation of the Kubernetes Security Audit vendors
- Review of publicly handled CSI logging bug
- Documentation moves for Security Committee formation

Further, Joel joined as an associate member based on his experience as
part of the OpenShift Online Security team which is a hosted
Kubernetes-base product.

Our process for accepting this nomination is lazy consensus and I will
close the round of consensus on March 15th, 2019 to leave time for any
comments or question. If the nomination is accepted Joel will take on
the full responsibilities of a Security Committee member and take on a
weekly rotation for security@kubernetes.io on-call rotation.