### PR TITLE
Add guidance on when to handle reported vulnerabilities publicly and semi-publicly

### DIFF
--- a/security-release-process.md
+++ b/security-release-process.md
@@ -225,6 +225,10 @@ These steps should be completed within the 1-7 days of Disclosure.
 
 If the CVSS score is under 4.0 ([a low severity score](https://www.first.org/cvss/specification-document#i5)) or the assessed risk is low the Fix Team can decide to slow the release process down in the face of holidays, developer bandwidth, etc. These decisions must be discussed on the security@kubernetes.io mailing list.
 
+If the CVSS score is under 7.0 (a medium severity score), the Fix Lead may choose to carry out the fix semi-publicly. This means that PRs are made directly in the public kubernetes/kubernetes repo, while restricting discussion of the security aspects to private channels. The fix lead will make the determination whether there would be user harm in handling the fix publicly that outweighs the benefits of open engagement with the community.
+
+If the vulnerability requires [User Interaction](https://www.first.org/cvss/user-guide#5-4-User-Interaction), especially in client components like kubectl, the Fix Lead may choose to disclose the vulnerability before a fix is developed if they determine that users would be better off being warned against a specific interaction.
+
 ### Fix Disclosure Process
 
 With the Fix Development underway the Fix Lead needs to come up with an overall communication plan for the wider community. This Disclosure process should begin after the Fix Team has developed a Fix or mitigation so that a realistic timeline can be communicated to users.

--- a/security-release-process.md
+++ b/security-release-process.md
@@ -223,11 +223,28 @@ These steps should be completed within the 1-7 days of Disclosure.
 - The Fix Lead will request a CVE from the [Kubernetes CVE Numbering Authority](cve-requests.md).
 - The Fix Team will notify the Fix Lead that work on the fix branch is complete once there are LGTMs on all commits in the private repo from one or more relevant assignees in the relevant OWNERS file.
 
-If the CVSS score is under 4.0 ([a low severity score](https://www.first.org/cvss/specification-document#i5)) or the assessed risk is low the Fix Team can decide to slow the release process down in the face of holidays, developer bandwidth, etc. These decisions must be discussed on the security@kubernetes.io mailing list.
+If the CVSS score is under ~4.0
+([a low severity score](https://www.first.org/cvss/specification-document#i5))
+or the assessed risk is low the Fix Team can decide to slow the release process
+down in the face of holidays, developer bandwidth, etc. These decisions must be
+discussed on the security@kubernetes.io mailing list.
 
-If the CVSS score is under 7.0 (a medium severity score), the Fix Lead may choose to carry out the fix semi-publicly. This means that PRs are made directly in the public kubernetes/kubernetes repo, while restricting discussion of the security aspects to private channels. The fix lead will make the determination whether there would be user harm in handling the fix publicly that outweighs the benefits of open engagement with the community.
+If the CVSS score is under ~7.0 (a medium severity score), the Fix Lead may
+choose to carry out the fix semi-publicly. This means that PRs are made directly
+in the public kubernetes/kubernetes repo, while restricting discussion of the
+security aspects to private channels. The fix lead will make the determination
+whether there would be user harm in handling the fix publicly that outweighs the
+benefits of open engagement with the community.
 
-If the vulnerability requires [User Interaction](https://www.first.org/cvss/user-guide#5-4-User-Interaction), especially in client components like kubectl, the Fix Lead may choose to disclose the vulnerability before a fix is developed if they determine that users would be better off being warned against a specific interaction.
+Note: CVSS is convenient but imperfect. Ultimately, the fix lead has discretion
+on classifying the severity of a vulnerability.
+
+No matter the CVSS score, if the vulnerability requires
+[User Interaction](https://www.first.org/cvss/user-guide#5-4-User-Interaction),
+especially in client components like kubectl, or otherwise has a
+straightforward, non-disruptive mitigation, the Fix Lead may choose to disclose
+the vulnerability before a fix is developed if they determine that users would
+be better off being warned against a specific interaction.
 
 ### Fix Disclosure Process
 


### PR DESCRIPTION
We've had a few recent vulnerabilities that we ad-hoc chose to handle "semi-publicly." I think this was the correct choice in those cases, but our process doesn't mention "fix in the open but quietly" as an option, and I want to make sure we aren't choosing to handle publicly just because we're tired of dealing with other critical vulns. I want to codify our "public option" a little more, both to be more transparent to the rest of the community, and to help guide our own decisions.

@tallclair also made a good point about client-side stuff having slightly different implications, so there's a sentence about that as well.

I'm hoping to talk about this at sig-auth on 5/1 to get some more input from folks who may have thought through this in other places.