### PR TITLE
Add oss-security[at]lists.openwall.com to security announcements.

### DIFF
--- a/email-templates.md
+++ b/email-templates.md
@@ -5,7 +5,7 @@ This is a collection of email templates to handle various situations the PSC nee
 ## Security Fix Announcement
 
 Subject: [ANNOUNCE] Security release of $COMPONENT $VERSION - $CVE
-To: kubernetes-dev@googlegroups.com, kubernetes-security-announce@googlegroups.com, kubernetes-security-discuss@googlegroups.com
+To: kubernetes-dev@googlegroups.com, kubernetes-security-announce@googlegroups.com, kubernetes-security-discuss@googlegroups.com, oss-security@lists.openwall.com
 
 Hello Kubernetes Community-
 


### PR DESCRIPTION
As discussed on the mailing list:

https://groups.google.com/forum/#!msg/kubernetes-security-discuss/pcZJ3fdSn80/DHJWV8jaAQAJ

I am taking option 2 recommended by @philips to add oss-security to the email template.