### PR TITLE
private-distributors-list: add canonical

### DIFF
--- a/private-distributors-list.md
+++ b/private-distributors-list.md
@@ -71,6 +71,7 @@ could be in the form of the following:
 | security@vmware.com | VMware |
 | upstream-security@heptio.com | Heptio |
 | vulnerabilityreports@cloudfoundry.org | Cloud Foundry |
+| security@ubuntu.com | Canonical |
 
 ### Membership Criteria
 


### PR DESCRIPTION
<!--
Please answer the following questions and provide supporting evidence for
meeting the membership criteria.
-->

**Actively monitored security email alias for our project:**
security@ubuntu.com

**1. Be an actively maintained and CNCF certified distribution of Kubernetes components.**
Canonical distributes and supports CNCF Kubernetes systems.

**2. Have a user base not limited to your own organization.**
Yes

**3. Have a publicly verifiable track record up to present day of fixing security issues.**
Please view usn.ubuntu.com to see the list of issues we have fixed over time.

**4. Not be a downstream or rebuild of another distribution.**
We are not.

**5. Be a participant and active contributor in the community.**
We are an active participant to the k8s community.

**6. Accept the Embargo Policy.**
<!-- https://github.com/kubernetes/security/blob/master/private-distributors-list.md#embargo-policy -->
Yes, the security team is aware of and participates in embargoed security issues.

**7. Be willing to contribute back.**
<!-- Per https://github.com/kubernetes/security/blob/master/private-distributors-list.md#contributing-back -->
As a proud member of the Open Source community we would be happy to commit back.

**8. Have someone already on the list vouch for the person requesting membership on behalf of your distribution.**
Jorge Castro should be able to vouch for us.

Please let me know if you have any questions! -Joe

Fixes https://github.com/kubernetes/security/issues/29