### PR TITLE
security-release-process: add two new associate members

### DIFF
--- a/security-release-process.md
+++ b/security-release-process.md
@@ -81,6 +81,8 @@ The initial Product Security Committee will consist of volunteers subscribed to 
 
 - Micah Hausler (**[@micahhausler](https://github.com/micahhausler)**) `<mhausler@amazon.com>`
 - Jonathan Pulsifer (**[@jonpulsifer](https://github.com/jonpulsifer)**) `<jonathan.pulsifer@shopify.com>`
+- Luke Hinds (**[@lukehinds](https://github.com/lukehinds)**) `lhinds@redhat.com`
+- Swamy Shivaganga Nagaraju (**[@swamymsft](https://github.com/swamymsft)**) `<gaswamy@microsoft.com>`
 
 ### Contacting the Team
 


### PR DESCRIPTION
I will be mentoring two new associate members with the goal of getting
them onboard by September/October.

Luke Hinds works in the Office of the CTO for Red Hat and has a long history helping open source projects handle security incidents. He has served as Project Team Lead of the OpenStack Security Project which included a number of experiences  performing secure code review,  managing embargoed security notes, and proactive scanning in CI gate with bandit.  Further he was Security Manager for the OpenDayLight software defined networking system and managed all embargoed security vulnerabilities and helped to implement various proactive check systems (e.g. Java CI checks). He also set up the OPNFV security group and created their Vulnerability reporting process.

Swamy Shivaganga Nagaraju, works for Microsoft Security Response Centre (MSRC) and since 2012 he has worked on hundreds of security issues and discovered many  issues through variant investigation and bug hunting in components of Windows. Through his vulnerability research work he has also developed fuzzing tools and frameworks. Further, he has worked on various mitigations that have made it into products, such as CFG Export Suppression, Attack Surface Reductions & Dll Planting mitigations.