### PR TITLE
Promote Jon Pulsifer to full PSC member

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,6 +4,7 @@ aliases:
   product-security-committee:
     - cjcullen
     - joelsmith
+    - jonpulsifer
     - liggitt
     - philips
     - tallclair

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -12,6 +12,7 @@
 
 cjcullen
 joelsmith
+jonpulsifer
 liggitt
 philips
 tallclair

--- a/security-release-process.md
+++ b/security-release-process.md
@@ -76,11 +76,11 @@ The initial Product Security Committee will consist of volunteers subscribed to 
 - Tim Allclair (**[@tallclair](https://github.com/tallclair)**) `<tallclair@google.com>` [4096R/0x5E6F2E2DA760AF51]
 - Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) `<jordan@liggitt.net>` [4096R/0x39928704103C7229]
 - Joel Smith (**[@joelsmith](https://github.com/joelsmith)**) `<joelsmith@redhat.com>`
+- Jonathan Pulsifer (**[@jonpulsifer](https://github.com/jonpulsifer)**) `<jonathan.pulsifer@shopify.com>`
 
 [Associate](#Associate) members include:
 
 - Micah Hausler (**[@micahhausler](https://github.com/micahhausler)**) `<mhausler@amazon.com>`
-- Jonathan Pulsifer (**[@jonpulsifer](https://github.com/jonpulsifer)**) `<jonathan.pulsifer@shopify.com>`
 - Luke Hinds (**[@lukehinds](https://github.com/lukehinds)**) `lhinds@redhat.com`
 - Swamy Shivaganga Nagaraju (**[@swamymsft](https://github.com/swamymsft)**) `<gaswamy@microsoft.com>`
 


### PR DESCRIPTION
Following the process documented in https://github.com/kubernetes/security/pull/37. Once this PR merges, I'll follow the rest of the steps - but let's treat this one as the source of truth.