### PR TITLE
Fix Associate link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Product Security Committee (PSC) is responsible for triaging and handling th
 - Joel Smith (**[@joelsmith](https://github.com/joelsmith)**) `<joelsmith@redhat.com>`
 - Jonathan Pulsifer (**[@jonpulsifer](https://github.com/jonpulsifer)**) `<jonathan.pulsifer@shopify.com>`
 
-[Associate](#Associate) members include:
+[Associate](security-release-process.md#associate) members include:
 - Micah Hausler (**[@micahhausler](https://github.com/micahhausler)**) `<mhausler@amazon.com>`
 - Luke Hinds (**[@lukehinds](https://github.com/lukehinds)**) `lhinds@redhat.com`
 - Swamy Shivaganga Nagaraju (**[@swamymsft](https://github.com/swamymsft)**) `<gaswamy@microsoft.com>`


### PR DESCRIPTION
The link to the description of Associate members in the README is broken. This PR updates the link.