### PR TITLE
Adding kubernetes-announce and discourse addresses to the email template

### DIFF
--- a/email-templates.md
+++ b/email-templates.md
@@ -5,7 +5,7 @@ This is a collection of email templates to handle various situations the PSC nee
 ## Security Fix Announcement
 
 Subject: [ANNOUNCE] Security release of $COMPONENT $VERSION - $CVE
-To: kubernetes-dev@googlegroups.com, kubernetes-security-announce@googlegroups.com, kubernetes-security-discuss@googlegroups.com, oss-security@lists.openwall.com
+To: kubernetes-announce@googlegroups.com, kubernetes-dev@googlegroups.com, kubernetes-security-announce@googlegroups.com, kubernetes-security-discuss@googlegroups.com, oss-security@lists.openwall.com, kubernetes+announcements@discoursemail.com
 
 Hello Kubernetes Community-
 


### PR DESCRIPTION
This adds two emails we were missing from the template for security
announcements:

- kubernetes-announce@googlegroups.com
- kubernetes+announcements@discoursemail.com

Signed-off-by: Jonathan Pulsifer <jonathan@pulsifer.ca>