### PR TITLE
README: add Luke Hinds to Security Committee

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ The Product Security Committee (PSC) is responsible for triaging and handling th
 - Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) `<jordan@liggitt.net>` [4096R/0x39928704103C7229]
 - Joel Smith (**[@joelsmith](https://github.com/joelsmith)**) `<joelsmith@redhat.com>`
 - Jonathan Pulsifer (**[@jonpulsifer](https://github.com/jonpulsifer)**) `<jonathan.pulsifer@shopify.com>`
+- Luke Hinds (**[@lukehinds](https://github.com/lukehinds)**) `lhinds@redhat.com`
 
 [Associate](security-release-process.md#associate) members include:
 - Micah Hausler (**[@micahhausler](https://github.com/micahhausler)**) `<mhausler@amazon.com>`
-- Luke Hinds (**[@lukehinds](https://github.com/lukehinds)**) `lhinds@redhat.com`
 - Swamy Shivaganga Nagaraju (**[@swamymsft](https://github.com/swamymsft)**) `<gaswamy@microsoft.com>`
 
 ### Contacting the PSC


### PR DESCRIPTION
Nomination email sent to kubernetes-security-discuss

https://groups.google.com/forum/#!forum/kubernetes-security-discuss

I want to nominate Luke Hinds to join the Product Security Committee as
a full member. He has been an associate member since June 26th 2019
and in that role over the last three months he has helped on a number of
tasks including:

- Coordinating CVE-2019-11251 announcement
- Writing Kubernetes Security Committee on-boarding guide

Our process for accepting this nomination is lazy consensus and I will
close the round of consensus on Oct 18th, 2019 to leave time for any
comments or question. If the nomination is accepted Luke will take on
the full responsibilities of a Security Committee member and take on a
weekly rotation for security@kubernetes.io on-call rotation.