### PR TITLE
Include distributors-announce in public security announcements

### DIFF
--- a/email-templates.md
+++ b/email-templates.md
@@ -5,7 +5,7 @@ This is a collection of email templates to handle various situations the PSC nee
 ## Security Fix Announcement
 
 Subject: [ANNOUNCE] Security release of $COMPONENT $VERSION - $CVE
-To: kubernetes-announce@googlegroups.com, kubernetes-dev@googlegroups.com, kubernetes-security-announce@googlegroups.com, kubernetes-security-discuss@googlegroups.com, oss-security@lists.openwall.com, kubernetes+announcements@discoursemail.com
+To: kubernetes-announce@googlegroups.com, kubernetes-dev@googlegroups.com, kubernetes-security-announce@googlegroups.com, kubernetes-security-discuss@googlegroups.com, oss-security@lists.openwall.com, kubernetes+announcements@discoursemail.com, distributors-announce@kubernetes.io
 
 Hello Kubernetes Community-
 


### PR DESCRIPTION
Rather than forcing distributors to join one of the public lists, let's just include the private list in public announcements.