### PR TITLE
Update vulnerability announcement template & add issue template

### DIFF
--- a/comms-temlpates/distributors-removal-email.md
+++ b/comms-temlpates/distributors-removal-email.md
@@ -1,0 +1,18 @@
+Subject: Kubernetes Disclosure List Removal Due to Uncertified Status
+
+Hello $MEMBER-
+
+The [Kubernetes Product Security Committee][psc] has removed $EMAIL from the distributors-announce@kubernetes.io Google Group.
+
+This is because $PRODUCT is no longer a [certified Kubernetes Distribution][conformance], a requirement for membership to this list.
+
+If $PRODUCT recertifies, and meets all other criteria, please submit a [request to re-join using the normal process][join-process].
+
+Thank You,
+
+$PERSON on behalf of the Kubernetes Product Security Committee
+
+[psc]: https://git.k8s.io/security/security-release-process.md#product-security-committee-psc
+[conformance]: https://www.cncf.io/certification/software-conformance/
+[criteria]: https://git.k8s.io/security/private-distributors-list.md#membership-criteria
+[join-process]: https://git.k8s.io/security/private-distributors-list.md#request-to-join

--- a/comms-temlpates/distributors-removal-email.md
+++ b/comms-temlpates/distributors-removal-email.md
@@ -1,4 +1,8 @@
-Subject: Kubernetes Disclosure List Removal Due to Uncertified Status
+TO: `$MEMBER_EMAIL`
+CC: `security-discuss-private@kubernetes.io`
+SUBJECT: `Kubernetes Disclosure List Removal Due to Uncertified Status`
+
+---
 
 Hello $MEMBER-
 

--- a/comms-temlpates/vulnerability-announcement-email.md
+++ b/comms-temlpates/vulnerability-announcement-email.md
@@ -1,35 +1,57 @@
-Subject: [ANNOUNCE] Security release of $COMPONENT $VERSION - $CVE
-To: kubernetes-announce@googlegroups.com, kubernetes-dev@googlegroups.com, kubernetes-security-announce@googlegroups.com, kubernetes-security-discuss@googlegroups.com, oss-security@lists.openwall.com, kubernetes+announcements@discoursemail.com
+_Use this email template for publicly disclosing security vulnerabilities._
 
-Hello Kubernetes Community-
+_The email should be **concise** and **actionable**. Assume the audience are not
+Kubernetes developers. Non-actionable information (e.g. technical discussion of
+the vulnerability) should be deferred to the [vulnerability
+issue](vulnerability-announcement-issue.md)._
 
-A security issue was discovered in versions of $COMPONENT versions $OLDVERSION or older. The issue is $SEVERITY and upgrading to $VERSION of $COMPONENT is encouraged to fix this issue.
+TO: `kubernetes-announce@googlegroups.com, kubernetes-dev@googlegroups.com, kubernetes-security-announce@googlegroups.com, kubernetes-security-discuss@googlegroups.com, oss-security@lists.openwall.com, kubernetes+announcements@discoursemail.com`
 
-**Am I vulnerable?**
+SUBJECT: `[Security Advisory] $CVE: $SUMMARY`
 
-Run `$COMPONENT version` and if it says $OLDVERSION or older you are running a vulnerable version.
+---
 
-**How do I mitigate the vulnerability?**
+Hello Kubernetes Community,
 
-<!--
-[This is an optional section. Remove if there are no mitigations.]
--->
+A security issue was discovered in $COMPONENT that could $BAD_STUFF _(brief description of impact)_.
 
-Run `kubectl delete deployment cookie-monster -n gibson` to temporarily disable the feature.
+This issue has been rated **$SEVERITY** (optional: $SCORE, link to CVSS calculator), and assigned **$CVE_NUMBER** (, other identifiers).
 
-**How do I upgrade?**
+### Am I vulnerable?
 
-Run `$COMPONENT upgrade` or follow the upgrade instructions at https://kubernetes.io/docs
+_How to determine if a cluster is impacted. Include:_
+- _Vulnerable configuration details_
+- _Commands that indicate whether a component, version or configuration is used_
 
-**Vulnerability Details**
+#### Affected Versions
 
-When $COMPONENT $OLDVERSION is run with default settings it will immediately shut the internet off.
+- $COMPONENT $VERSION_RANGE_1
+- $COMPONENT $VERSION_RANGE_2 ...
+- ...
+
+### How do I mitigate this vulnerability?
+
+_(If additional steps required after upgrade)_
+**ACTION REQUIRED:** The following steps must be taken to mitigate this
+vulnerability: ...
+
+_(If possible):_ Prior to upgrading, this vulnerability can be mitigated by ...
+
+#### Fixed Versions
+
+- $COMPONENT $VERSION
+- $COMPONENT $VERSION
+- ...
+
+_(If fix has side effects)_ **Fix impact:** details of impact.
+
+To upgrade, refer to the documentation: ... ($COMPONENT upgrade documentation)
+
+_For core Kubernetes:_ https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/#upgrading-a-cluster
+
+#### Addiitonal Details
 
 This issue is filed as $CVE. [See the GitHub issue for more details]($GITHUBISSUEURL)
-
-**Thank you**
-
-Thank you to $REPORTER, $DEVELOPERS, and the $RELEASEMANAGERS for the coordination is making this release.
 
 Thank You,
 

--- a/comms-temlpates/vulnerability-announcement-email.md
+++ b/comms-temlpates/vulnerability-announcement-email.md
@@ -1,9 +1,3 @@
-# Kubernetes Security Process Email Templates
-
-This is a collection of email templates to handle various situations the PSC needs to handle.
-
-## Security Fix Announcement
-
 Subject: [ANNOUNCE] Security release of $COMPONENT $VERSION - $CVE
 To: kubernetes-announce@googlegroups.com, kubernetes-dev@googlegroups.com, kubernetes-security-announce@googlegroups.com, kubernetes-security-discuss@googlegroups.com, oss-security@lists.openwall.com, kubernetes+announcements@discoursemail.com
 
@@ -40,25 +34,3 @@ Thank you to $REPORTER, $DEVELOPERS, and the $RELEASEMANAGERS for the coordinati
 Thank You,
 
 $PERSON on behalf of the Kubernetes Product Security Committee
-
-
-## Distributor List Removal
-
-Subject: Kubernetes Disclosure List Removal Due to Uncertified Status
-
-Hello $MEMBER-
-
-The [Kubernetes Product Security Committee][psc] has removed $EMAIL from the distributors-announce@kubernetes.io Google Group.
-
-This is because $PRODUCT is no longer a [certified Kubernetes Distribution][conformance], a requirement for membership to this list.
-
-If $PRODUCT recertifies, and meets all other criteria, please submit a [request to re-join using the normal process][join-process].
-
-Thank You,
-
-$PERSON on behalf of the Kubernetes Product Security Committee
-
-[psc]: https://git.k8s.io/security/security-release-process.md#product-security-committee-psc
-[conformance]: https://www.cncf.io/certification/software-conformance/
-[criteria]: https://git.k8s.io/security/private-distributors-list.md#membership-criteria
-[join-process]: https://git.k8s.io/security/private-distributors-list.md#request-to-join

--- a/comms-temlpates/vulnerability-announcement-issue.md
+++ b/comms-temlpates/vulnerability-announcement-issue.md
@@ -1,0 +1,39 @@
+_Use this issue template for filing CVE informational issues._
+
+TITLE: `CVE-####-######: $SUMMARY`
+
+---
+
+<!-- Copy URL after # as the link text -->
+CVSS Rating: [CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:L](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:L)
+
+_Description of vulnerability_
+
+<!-- Copy these sections from the announcement email -->
+
+### Am I vulnerable?
+#### Affected Versions
+### How do I mitigate this vulnerability?
+#### Fixed Versions
+<!-- Add links to PRs & master branch -->
+- $COMPONENT master - fixed by #12345678
+
+## Additional Details
+
+_Optional details:_
+- Vulnerability background
+- Technical explanation of vulnerability and/or fix
+- Reproduction steps (avoid disclosing unnecessary details)
+
+#### Acknowledgements
+
+This vulnerability was reported by $REPORTER.
+
+The issue was fixed and coordinated by $FIXTEAM and $RELEASE_MANAGERS.
+
+<!-- labels -->
+/area security
+/kind bug
+/committee product-security
+/sig $RELEVANT_SIGS
+/component $IMPACTED_COMPONENTS

--- a/comms-temlpates/vulnerability-announcement-issue.md
+++ b/comms-temlpates/vulnerability-announcement-issue.md
@@ -12,11 +12,36 @@ _Description of vulnerability_
 <!-- Copy these sections from the announcement email -->
 
 ### Am I vulnerable?
+
+_How to determine if a cluster is impacted. Include:_
+- _Vulnerable configuration details_
+- _Commands that indicate whether a component, version or configuration is used_
+
 #### Affected Versions
+
+- $COMPONENT $VERSION_RANGE_1
+- $COMPONENT $VERSION_RANGE_2 ...
+- ...
+
 ### How do I mitigate this vulnerability?
+
+_(If additional steps required after upgrade)_
+**ACTION REQUIRED:** The following steps must be taken to mitigate this
+vulnerability: ...
+
+_(If possible):_ Prior to upgrading, this vulnerability can be mitigated by ...
+
 #### Fixed Versions
+
 <!-- Add links to PRs & master branch -->
 - $COMPONENT master - fixed by #12345678
+- ...
+
+_(If fix has side effects)_ **Fix impact:** details of impact.
+
+To upgrade, refer to the documentation: ... ($COMPONENT upgrade documentation)
+
+_For core Kubernetes:_ https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/#upgrading-a-cluster
 
 ## Additional Details
 


### PR DESCRIPTION
- Refactor templates to a "comms-templates" directory & split up email templates into separate files
- Modify the vulnerability email template to be more concise and actionable. Everything else should be deferred to the issue.
- Add a vulnerability announcement issue template with additional details.