### PR TITLE
Minor template cleanup

### DIFF
--- a/comms-temlpates/vulnerability-announcement-email.md
+++ b/comms-temlpates/vulnerability-announcement-email.md
@@ -51,7 +51,7 @@ _For core Kubernetes:_ https://kubernetes.io/docs/tasks/administer-cluster/clust
 
 #### Addiitonal Details
 
-This issue is filed as $CVE. [See the GitHub issue for more details]($GITHUBISSUEURL)
+See the GitHub issue for more details: $GITHUBISSUEURL
 
 Thank You,
 

--- a/comms-temlpates/vulnerability-announcement-issue.md
+++ b/comms-temlpates/vulnerability-announcement-issue.md
@@ -61,4 +61,4 @@ The issue was fixed and coordinated by $FIXTEAM and $RELEASE_MANAGERS.
 /kind bug
 /committee product-security
 /sig $RELEVANT_SIGS
-/component $IMPACTED_COMPONENTS
+/area $IMPACTED_COMPONENTS


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/security/pull/61 to fix 2 minor issues I missed:
- Email links should be displayed in full (maybe we don't care... the email already renders poorly in plain-text)
- Apparently component labels were removed (combined with area)
- Remove duplicate reference to CVE assignment.