### PR TITLE
Add Craig Ingram (@cji) as associate member

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The Product Security Committee (PSC) is responsible for triaging and handling th
 - Tim Allclair (**[@tallclair](https://github.com/tallclair)**) `<tallclair@google.com>`
 
 [Associate](security-release-process.md#associate) members include:
+- Craig Ingram (**[@cji](https://github.com/cji)**) `<craig.ingram@salesforce.com>`
 - Swamy Shivaganga Nagaraju (**[@swamymsft](https://github.com/swamymsft)**) `<gaswamy@microsoft.com>`
 
 Emeritus members:


### PR DESCRIPTION
I propose that we add Craig Ingram (@cji) as an associate member of the Product
Security Committee. Craig and I work together as 2 of the leads of
[wg-security-audit](https://github.com/kubernetes/community/tree/master/wg-security-audit) and he helped coordinate the 2019 Kubernetes third-party security audit.
Craig impresses me as someone who is security minded, detail oriented and
follows through on assignments. Here's a brief bio:

> Craig Ingram is a principal security engineer at Salesforce and has over 15
> years of experience in information security.
>
> His current role includes performing threat modeling and architecture
> review, secure code review, penetration testing, security research, reverse
> engineering, and exploit development with a focus on containers and cloud
> infrastructure.
>
> Craig is an active participant in many public and private bug bounty
> programs.
>
> Most recently Craig has been a member of the Kubernetes Security Audit
> working group, where he helped with the organization and execution of the
> first full third-party security audit of the Kubernetes project.