### PR TITLE
Proposal to add Mo Khan as an associate member

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The Product Security Committee (PSC) is responsible for triaging and handling th
 [Associate](security-release-process.md#associate) members include:
 - Craig Ingram (**[@cji](https://github.com/cji)**) `<craig.ingram@salesforce.com>`
 - Swamy Shivaganga Nagaraju (**[@swamymsft](https://github.com/swamymsft)**) `<gaswamy@microsoft.com>`
+- Mo Khan (**[@enj](https://github.com/enj)**) `<mok@vmware.com>`
 
 Emeritus members:
 - Brandon Philips (**[@philips](https://github.com/philips)**) `<bphilips@redhat.com>`


### PR DESCRIPTION
In the spirit of [adding people with three-letter github handles](https://github.com/kubernetes/security/pull/72), I propose adding Mo Khan (@enj) as an associate member of the Product Security Committee. Mo and I worked together at Red Hat, he is deeply familiar with Kubernetes security controls and architecture, currently serves as a chair of sig-auth, and is very involved as a [reviewer](https://github.com/kubernetes/kubernetes/issues?q=commenter%3Aenj+assignee%3Aenj+label%3Asig%2Fauth) and [contributor](https://github.com/kubernetes/kubernetes/issues?q=author%3Aenj).

/cc @cjcullen @joelsmith @lukehinds @micahhausler @tallclair 