### PR TITLE
Change 'will' to 'may' for creation of private branches

### DIFF
--- a/security-release-process.md
+++ b/security-release-process.md
@@ -177,7 +177,7 @@ our users.
 These steps should be completed within the first 24 hours of Disclosure.
 
 - The Fix Lead will work quickly to identify relevant engineers from the affected projects and packages and CC those engineers into the disclosure thread. This selected developers are the Fix Team. A best guess is to invite all assignees in the OWNERS file from the affected packages.
-- The Fix Lead will get the Fix Team access to private security repos in the kubernetes-security GitHub org to develop the fix.
+- The Fix Lead may get the Fix Team access to private security repos in the kubernetes-security GitHub org to develop the fix as required.
 
 Note: The kubernetes-security GitHub org is co-owned and viewable by the PSC and Kubernetes Release Managers. Management of the org is done by SIG Contributor Experience's [GitHub management subproject](https://git.k8s.io/community/github-management).
 


### PR DESCRIPTION
As discussed in 'Fix Development Process' section below private repos are sometimes not used when developing fixes for issues which are considered medium or lower. So stating that the Fix Lead "will" create such a repo seems incorrect.