### PR TITLE
Add Sam Fowler as associate member

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The Product Security Committee (PSC) is responsible for triaging and handling th
 - Craig Ingram (**[@cji](https://github.com/cji)**) `<craig.ingram@salesforce.com>`
 - Swamy Shivaganga Nagaraju (**[@swamymsft](https://github.com/swamymsft)**) `<gaswamy@microsoft.com>`
 - Mo Khan (**[@enj](https://github.com/enj)**) `<mok@vmware.com>`
+- Sam Fowler (**[@sfowl](https://github.com/sfowl)**) `<sfowler@redhat.com>`
 
 Emeritus members:
 - Brandon Philips (**[@philips](https://github.com/philips)**) `<bphilips@redhat.com>`


### PR DESCRIPTION
I will mentor Sam Fowler with the view of graduation from associate
to full member of the PSC.

Sam Fowler is a senior analyst in Red Hat's Product Security team with a
focus on the Kubernetes based OpenShift product. On this team he is
responsible for response to security disclosures, handling embargoed
vulnerabilities, security hardening and productization. He has formerly
held developer and security testing roles at Boeing, Dolby and IBM.