### PR TITLE
Add GPG key info for joelsmith

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Kubernetes Security Release Process and Security Committee documentation.
 The Product Security Committee (PSC) is responsible for triaging and handling the security issues for Kubernetes. Following are the current Product Security Committee members:
 
 - CJ Cullen (**[@cjcullen](https://github.com/cjcullen)**) `<cjcullen@google.com>`
-- Joel Smith (**[@joelsmith](https://github.com/joelsmith)**) `<joelsmith@redhat.com>`
+- Joel Smith (**[@joelsmith](https://github.com/joelsmith)**) `<joelsmith@redhat.com>` [4096R/0x1688ADC79BECDDAF]
 - Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) `<jordan@liggitt.net>` [4096R/0x39928704103C7229]
 - Luke Hinds (**[@lukehinds](https://github.com/lukehinds)**) `lhinds@redhat.com`
 - Micah Hausler (**[@micahhausler](https://github.com/micahhausler)**) `<mhausler@amazon.com>`


### PR DESCRIPTION
You can verify the key ID of my key as posted to these two keyservers:
```
gpg --search-keys --keyserver https://keys.openpgp.org joelsmith@redhat.com
gpg --search-keys --keyserver pgp.mit.edu joelsmith@redhat.com
```