### PR TITLE
Promote associate Craig Ingram (@cji) to the PSC

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,6 +3,7 @@
 aliases:
   product-security-committee:
     - cjcullen
+    - cji
     - joelsmith
     - liggitt
     - lukehinds

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Kubernetes Security Release Process and Security Committee documentation.
 The Product Security Committee (PSC) is responsible for triaging and handling the security issues for Kubernetes. Following are the current Product Security Committee members:
 
 - CJ Cullen (**[@cjcullen](https://github.com/cjcullen)**) `<cjcullen@google.com>`
+- Craig Ingram (**[@cji](https://github.com/cji)**) `<craig.ingram@salesforce.com>`
 - Joel Smith (**[@joelsmith](https://github.com/joelsmith)**) `<joelsmith@redhat.com>` [4096R/0x1688ADC79BECDDAF]
 - Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) `<jordan@liggitt.net>` [4096R/0x39928704103C7229]
 - Luke Hinds (**[@lukehinds](https://github.com/lukehinds)**) `lhinds@redhat.com`
@@ -14,7 +15,6 @@ The Product Security Committee (PSC) is responsible for triaging and handling th
 - Tim Allclair (**[@tallclair](https://github.com/tallclair)**) `<tallclair@google.com>`
 
 [Associate](security-release-process.md#associate) members include:
-- Craig Ingram (**[@cji](https://github.com/cji)**) `<craig.ingram@salesforce.com>`
 - Swamy Shivaganga Nagaraju (**[@swamymsft](https://github.com/swamymsft)**) `<gaswamy@microsoft.com>`
 - Mo Khan (**[@enj](https://github.com/enj)**) `<mok@vmware.com>`
 

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -11,6 +11,7 @@
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
 cjcullen
+cji
 joelsmith
 liggitt
 micahhausler


### PR DESCRIPTION
I propose that we promote Craig Ingram (@cji) to a member of the Product Security Committee. Craig and I worked together as 2 of the leads of [wg-security-audit](https://github.com/kubernetes/community/tree/master/wg-security-audit) and he helped coordinate the 2019 Kubernetes third-party security audit.  Craig impresses me as someone who is security minded, detail oriented and follows through on assignments. In his time as an associate, he has helped to improve our distributor and public disclosure processes (see #83) and is currently handling communications for an embargoed medium issue.

Here's a brief bio:

> Craig Ingram is a principal security engineer at Salesforce and has over 15
> years of experience in information security.
>
> His current role includes performing threat modeling and architecture
> review, secure code review, penetration testing, security research, reverse
> engineering, and exploit development with a focus on containers and cloud
> infrastructure.
>
> Craig is an active participant in many public and private bug bounty
> programs.
>
> Most recently Craig has been a member of the Kubernetes Security Audit
> working group, where he helped with the organization and execution of the
> first full third-party security audit of the Kubernetes project.

Craig will hit the 3-month mark as an associate on Wednesday, June 10.

Hold until after June 10 and until we reach consensus.
/hold