### PR TITLE
Add GitHub PSC group to on/offboard process

### DIFF
--- a/psc-onboarding-offboarding.md
+++ b/psc-onboarding-offboarding.md
@@ -79,6 +79,29 @@ aliases:
     - jdoe
 ```
 
+##### file: https://github.com/kubernetes/security/blob/master/SECURITY_CONTACTS
+
+Add / remove the PSC member(s) github name from the alphabetized list in
+`security/SECURITY_CONTACTS`.
+
+```
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Committee to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+...
+jdoe
+...
+```
+
 #### kubernetes/k8s.io repository
 
 ##### file: https://github.com/kubernetes/k8s.io/blob/master/groups/groups.yaml
@@ -118,6 +141,27 @@ This will then automatically create the following files:
 * kubernetes/community/OWNERS_ALIASES
 * kubernetes/community/committee-product-security/README.md
 * kubernetes/community/sig-list.md
+
+#### kubernetes/org repository
+
+##### file: https://github.com/kubernetes/org/blob/master/config/kubernetes/org.yaml
+
+Add / remove the PSC member(s) github username from `config/kubernetes/org.yaml`
+to the existing `product-security-committee` | `members` field. The usernames
+should be alphabetized:
+
+```yaml
+  product-security-committee:
+    description: Please report security issues to https://kubernetes.io/security
+    members:
+    - alice
+    - bob
+    - jdoe
+```
+
+Once merged, [peribolos](https://git.k8s.io/test-infra/prow/cmd/peribolos) will
+automatically run and update the members of the GitHub group
+https://github.com/orgs/kubernetes/teams/product-security-committee
 
 ####  Add/remove from HackerOne
 


### PR DESCRIPTION
Our GitHub group https://github.com/orgs/kubernetes/teams/product-security-committee is out of date because our process doesn't include steps to maintain it. Thanks, @fejta for pointers on where to update it.