### PR TITLE
Remove Jordan Liggitt from PSC (stepping down)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The Product Security Committee (PSC) is responsible for triaging and handling th
 - CJ Cullen (**[@cjcullen](https://github.com/cjcullen)**) `<cjcullen@google.com>`
 - Craig Ingram (**[@cji](https://github.com/cji)**) `<craig.ingram@salesforce.com>`
 - Joel Smith (**[@joelsmith](https://github.com/joelsmith)**) `<joelsmith@redhat.com>` [4096R/0x1688ADC79BECDDAF]
-- Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) `<jordan@liggitt.net>` [4096R/0x39928704103C7229]
 - Luke Hinds (**[@lukehinds](https://github.com/lukehinds)**) `lhinds@redhat.com`
 - Micah Hausler (**[@micahhausler](https://github.com/micahhausler)**) `<mhausler@amazon.com>`
 - Tim Allclair (**[@tallclair](https://github.com/tallclair)**) `<tallclair@google.com>`
@@ -22,6 +21,7 @@ Emeritus members:
 - Brandon Philips (**[@philips](https://github.com/philips)**) `<bphilips@redhat.com>`
 - Jess Frazelle (**[@jessfraz](https://github.com/jessfraz)**) `<jess@linux.com>`
 - Jonathan Pulsifer (**[@jonpulsifer](https://github.com/jonpulsifer)**) `<jonathan.pulsifer@shopify.com>`
+- Jordan Liggitt (**[@liggitt](https://github.com/liggitt)**) `<jordan@liggitt.net>` [4096R/0x39928704103C7229]
 
 ### Contacting the PSC
 


### PR DESCRIPTION
Thanks @liggitt for all the work performed as a member of the PSC! I'm sure we'll continue to take advantage of your expertise when we work together on future issues. It's nice knowing that you're still around to weigh in when we need you!