### PR TITLE
Update contacts for Jordan's offboarding

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,7 +4,6 @@ aliases:
   product-security-committee:
     - cjcullen
     - joelsmith
-    - liggitt
     - lukehinds
     - micahhausler
     - tallclair

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -11,7 +11,7 @@
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
 cjcullen
+cji
 joelsmith
-liggitt
 micahhausler
 tallclair


### PR DESCRIPTION
Follow up from #91 (https://github.com/kubernetes/security/pull/91#issuecomment-646281333) removes Jordan from the OWNERS_ALIASES and SECURITY_CONTACTS file. 