### PR TITLE
Add an email template for distributors-announce notifications

### DIFF
--- a/comms-templates/distributors-announcement-email.md
+++ b/comms-templates/distributors-announcement-email.md
@@ -1,0 +1,60 @@
+_Use this email template for pre-disclosing security vulnerabilities to distributors-announce._
+
+TO: `distributors-announce@kubernetes.io`
+
+SUBJECT: `[EMBARGOED] $CVE: $SUMMARY`
+
+---
+
+### EMBARGOED
+
+The information contained in this email is **[under
+embargo](https://github.com/kubernetes/security/blob/master/private-distributors-list.md#embargo-policy)**
+until the scheduled public disclosure on **$DATE, at 9AM PT**.
+
+_Additional details on the embargo conditions._
+- _If a patch is provided, can it be deployed?_
+- _Is the patch itself under embargo?_
+
+### Issue Details
+
+A security issue was discovered in $COMPONENT that could $BAD_STUFF _(brief description of impact)_.
+
+This issue has been rated **$SEVERITY** (optional: $SCORE, link to CVSS calculator), and assigned
+**$CVE_NUMBER** (, other identifiers).
+
+_Additional high level description of the vulnerability._
+
+### Affected Components and Configurations
+
+_How to determine if a cluster is impacted. Include:_
+- _Vulnerable configuration details_
+- _Commands that indicate whether a component, version or configuration is used_
+
+#### Affected Versions
+
+- $COMPONENT $VERSION_RANGE_1
+- $COMPONENT $VERSION_RANGE_2 ...
+- ...
+
+### Mitigations
+
+_If a patch is provided, describe it here._
+
+_(If fix has side effects)_ **Fix impact:** details of impact.
+
+_(If additional steps required after upgrade)_
+**ACTION REQUIRED:** The following steps must be taken to mitigate this
+vulnerability: ...
+
+_(If possible):_ Prior to upgrading, this vulnerability can be mitigated by ...
+
+### Detection
+
+_How can exploitation of this vulnerability be detected?_
+
+If you find evidence that this vulnerability has been exploited, please contact security@kubernetes.io
+
+Thank You,
+
+$PERSON on behalf of the Kubernetes Product Security Committee

--- a/comms-templates/vulnerability-announcement-email.md
+++ b/comms-templates/vulnerability-announcement-email.md
@@ -49,6 +49,12 @@ To upgrade, refer to the documentation: ... ($COMPONENT upgrade documentation)
 
 _For core Kubernetes:_ https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/#upgrading-a-cluster
 
+### Detection
+
+_How can exploitation of this vulnerability be detected?_
+
+If you find evidence that this vulnerability has been exploited, please contact security@kubernetes.io
+
 #### Additional Details
 
 See the GitHub issue for more details: $GITHUBISSUEURL

--- a/comms-templates/vulnerability-announcement-issue.md
+++ b/comms-templates/vulnerability-announcement-issue.md
@@ -43,6 +43,12 @@ To upgrade, refer to the documentation: ... ($COMPONENT upgrade documentation)
 
 _For core Kubernetes:_ https://kubernetes.io/docs/tasks/administer-cluster/cluster-management/#upgrading-a-cluster
 
+### Detection
+
+_How can exploitation of this vulnerability be detected?_
+
+If you find evidence that this vulnerability has been exploited, please contact security@kubernetes.io
+
 ## Additional Details
 
 _Optional details:_


### PR DESCRIPTION
To help streamline our process, I'd like to add a template for embargoed notifications to distributors-announce. The content is a bit different from the public announcement, but I tried to keep the format close.

/assign @joelsmith @cji 