### PR TITLE
Fix "informing" spelling error and link to adjacent-network-access

### DIFF
--- a/security-release-process.md
+++ b/security-release-process.md
@@ -363,7 +363,7 @@ based on other considerations as documented here.
 
 Examples:
 - Disabling or bypassing a `NetworkPolicy` or `PodSecurityPolicy` without
-winforming users or gaining consent
+informing users or gaining consent
 - Reconfiguring a `NetworkPolicy` and allowing connections to other processes
 without consent
 

--- a/security-release-process.md
+++ b/security-release-process.md
@@ -312,7 +312,7 @@ not intended or designed to be exposed.
 #### High
 
 "Critical" attacks are downgraded to "High" when requiring
-[adjacent network access](adjacent-network-access).
+[adjacent network access](#adjacent-network-access).
 
 Non-default (or non-typical) critical scenarios or cases where
 mitigations exist that can help prevent critical scenarios.


### PR DESCRIPTION
Fixes a spelling error as well as a link to the link to the definition of adjacent network access