### PR TITLE
Update tallclair email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Product Security Committee (PSC) is responsible for triaging and handling th
 - Luke Hinds (**[@lukehinds](https://github.com/lukehinds)**) `lhinds@redhat.com`
 - Micah Hausler (**[@micahhausler](https://github.com/micahhausler)**) `<mhausler@amazon.com>`
 - Swamy Shivaganga Nagaraju (**[@swamymsft](https://github.com/swamymsft)**) `<gaswamy@microsoft.com>`
-- Tim Allclair (**[@tallclair](https://github.com/tallclair)**) `<tallclair@apple.com>`
+- Tim Allclair (**[@tallclair](https://github.com/tallclair)**) `<timallclair@gmail.com>`
 
 [Associate](security-release-process.md#associate) members include:
 - Mo Khan (**[@enj](https://github.com/enj)**) `<mok@vmware.com>`

--- a/cna-handbook.md
+++ b/cna-handbook.md
@@ -17,7 +17,7 @@ The following members of the Product Security Committee have completed CNA train
 
 - Joel Smith (**[@joelsmith](https://github.com/joelsmith)**) `<joelsmith@redhat.com>`
 - Micah Hausler (**[@micahhausler](https://github.com/micahhausler)**) `<mhausler@amazon.com>`
-- Tim Allclair (**[@tallclair](https://github.com/tallclair)**) `<tallclair@google.com>` [4096R/0x5E6F2E2DA760AF51]
+- Tim Allclair (**[@tallclair](https://github.com/tallclair)**) `<timallclair@gmail.com>`
 
 ## References
 


### PR DESCRIPTION
I'm now using `timallclair@gmail.com` for all open source communications.