### PR TITLE
docs: update distributors-announce file

### DIFF
--- a/private-distributors-list.md
+++ b/private-distributors-list.md
@@ -51,8 +51,8 @@ could be in the form of the following:
 ### Membership
 
 Group membership is managed through the Kubernetes domain group administration
-configuration: http://git.k8s.io/k8s.io/groups/groups.yaml, under the
-`distributors-announce` section.
+configuration: http://git.k8s.io/k8s.io/groups/committee-product-security/groups.yaml,
+under the `distributors-announce` section.
 
 ### Membership Criteria
 


### PR DESCRIPTION
https://github.com/kubernetes/k8s.io/pull/1822 moves the distributors-announce list to a groups.yaml file under committee-product-security ownership, to ensure relevant reviewers are assigned to PRs updating list membership

This PR updates docs to follow suit