### PR TITLE
Promote Tabitha Sable to full PSC member

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,4 +7,5 @@ aliases:
     - lukehinds
     - micahhausler
     - swamymsft
+    - tabbysable
     - tallclair

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ The Product Security Committee (PSC) is responsible for triaging and handling th
 - Luke Hinds (**[@lukehinds](https://github.com/lukehinds)**) `lhinds@redhat.com`
 - Micah Hausler (**[@micahhausler](https://github.com/micahhausler)**) `<mhausler@amazon.com>`
 - Swamy Shivaganga Nagaraju (**[@swamymsft](https://github.com/swamymsft)**) `<gaswamy@microsoft.com>`
+- Tabitha Sable (**[@tabbysable](https://github.com/tabbysable)**) `<tabitha.c.sable@gmail.com>`
 - Tim Allclair (**[@tallclair](https://github.com/tallclair)**) `<timallclair@gmail.com>`
 
 [Associate](security-release-process.md#associate) members include:
 - Mo Khan (**[@enj](https://github.com/enj)**) `<mok@vmware.com>`
 - Sam Fowler (**[@sfowl](https://github.com/sfowl)**) `<sfowler@redhat.com>`
-- Tabitha Sable (**[@tabbysable](https://github.com/tabbysable)**) `<tabitha.c.sable@gmail.com>`
 - Taahir Ahmed (**[@ahmedtd](https://github.com/ahmedtd)**) `<taahm@google.com>`
 
 Emeritus members:

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -15,4 +15,5 @@ joelsmith
 lukehinds
 micahhausler
 swamymsft
+tabbysable
 tallclair


### PR DESCRIPTION
As discussed offline, we would like to promote Tabitha to full PSC member to fill the vacancy when Craig stepped down. Tabitha has been helping out the PSC as an associate since Sep 14, 2020.