### PR TITLE
Add steps for syncing kubernetes-security from public repositories

### DIFF
--- a/security-release-process.md
+++ b/security-release-process.md
@@ -157,7 +157,9 @@ These steps should be completed within the 1-7 days of Disclosure.
 
 - The Fix Lead and the Fix Team will create a [CVSS](https://www.first.org/cvss/specification-document) score using the [CVSS Calculator](https://www.first.org/cvss/calculator/3.0). They will also use the [Severity Thresholds - How We Do Vulnerability Scoring](#severity-thresholds---how-we-do-vulnerability-scoring) to determine the effect and severity of the bug. The Fix Lead makes the final call on the calculated risk; it is better to move quickly than make the perfect assessment.
 - The Fix Lead will [Assign a CVE ID to the vulnerability from the CVE Numbering Authority](/cna-handbook.md#assign-a-cve-id-to-the-vulnerability).
-- The Fix Team will notify the Fix Lead that work on the fix branch is complete once there are LGTMs on all commits in the private repo from one or more relevant assignees in the relevant OWNERS file.
+- The Fix Lead will sync the master branch and active release branches from the public repo to the private security repo in the kubernetes-security GitHub organization using this script: [sync-repo.sh](tools/sync-repo.sh)
+- The Fix Team will notify the Fix Lead that work on the master and release branches is complete once there are LGTMs on all commits in the private repo from one or more relevant assignees in the relevant OWNERS file.
+- These pull requests should not be merged on the private kubernetes-security GitHub repo. The Fix Lead should reference these PRs for embargoed patch development and cherry-picking to the public repo on the fix release day.
 
 If the CVSS score is under ~4.0
 ([a low severity score](https://www.first.org/cvss/specification-document#i5))
@@ -197,6 +199,7 @@ With the Fix Development underway the Fix Lead needs to come up with an overall 
 **Advance Vulnerability Disclosure to Private Distributors List** (Completed within 1-4 weeks prior to public disclosure):
 
 - The [Private Distributors List](#private-distributors-list) will be given advance notification of any vulnerability that is assigned a CVE, at least 7 days before the planned public disclosure date. The notification will include all information that can be reasonably provided at the time of the notification. This may include patches or links to PRs, proofs of concept or instructions to reproduce the vulnerability, known mitigations, and timelines for public disclosure. When applicable, patches for all supported versions should be included. Distributors should read about the [Private Distributors List](#private-distributors-list) to find out the requirements for being added to this list.
+- The following script can be used to generate patch files from the kubernetes-security release branch PRs which were previously approved (but not merged): [patchformat.py](tools/patchformat.py). The patch files from each supported release branch should be included in a zipped file in the private distributor notification.
 - **What if a vendor breaks embargo?** The SRC will assess the damage. The Fix Lead will make the call to release earlier or continue with the plan. When in doubt push forward and go public ASAP.
 
 **Fix Release Day**

--- a/tools/sync-repo.sh
+++ b/tools/sync-repo.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# This script assumes that kubernetes/kubernetes is already checked out as a remote named upstream pointing to
+# https://github.com/kubernetes/kubernetes.git. Running this script will:
+# 1. Set a remote called security to kubernetes-security/kubernetes.
+# 2. Discover the branches which need synced which includes the master branch and all currently supported release branches.
+# 3. Checkout each of the upstream branches locally requiring syncing and push them to the corresponding security branches.
+# Example usage:
+# ./sync-repo.sh <path-to-kubernetes-repo>
+
+set -e
+kubernetes_dir=$1
+if [ -z $kubernetes_dir ]; then
+  echo "Pass argument for K8s directory: ./sync-repo.sh <kubernetes_dir>"
+  exit 1
+fi
+
+pushd "$kubernetes_dir"
+# Confirm that the given repo has a remote named upstream. Grep will fail with a non-zero exit code which will cause
+# the script to exit if this remote doesn't exist.
+git remote -v | grep 'upstream.*https://github.com/kubernetes/kubernetes.git' > /dev/null
+
+git remote add security https://github.com/kubernetes-security/kubernetes.git || true
+echo "Fetching from security and upstream remotes"
+git fetch security
+git fetch upstream
+
+# Checkout rules.yaml from upstream/master so that release branches are up-to-date
+git checkout upstream/master -- staging/publishing/rules.yaml
+sync_branches_source="staging/publishing/rules.yaml"
+sync_branches=$(cat $sync_branches_source | grep "branch:" | awk '{print $2;}'  | sort | uniq)
+
+for branch in $sync_branches; do
+  echo "*** Syncing branch $branch ***"
+  # Check out the upstream branch locally
+  git checkout -b tmp-sync upstream/$branch
+  # Push to fork's release branch
+  git push security tmp-sync:$branch
+  # Delete after sync
+  git checkout master
+  git branch -D tmp-sync
+  echo -e "Done syncing branch $branch\n"
+done
+
+popd


### PR DESCRIPTION
#### Notes
Update security-release-process to include steps for how to sync branches in kubernetes-security repos from the corresponding public repository. The overview includes the steps for how to update master, a remote branch that already exists in kubernetes-security, and a remote branch that does not exist in kubernetes-security.

#### Testing
Using the script to sync master + 1.30-1.34 release branches on my personal repo:
```
 % ./tools/sync-repo.sh /Users/nathanherz/go/kubernetes
~/go/kubernetes ~/go/committee-security-response
error: remote security already exists.
Fetching from security and upstream remotes
*** Syncing branch master ***
Updating files: 100% (20552/20552), done.
branch 'tmp-sync' set up to track 'upstream/master'.
Switched to a new branch 'tmp-sync'
Everything up-to-date
Updating files: 100% (20553/20553), done.
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Deleted branch tmp-sync (was 387f474920c).
Done syncing branch master

*** Syncing branch release-1.30 ***
Updating files: 100% (11227/11227), done.
branch 'tmp-sync' set up to track 'upstream/release-1.30'.
Switched to a new branch 'tmp-sync'
Everything up-to-date
Updating files: 100% (11227/11227), done.
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Deleted branch tmp-sync (was 433bffb8317).
Done syncing branch release-1.30

...

~/go/committee-security-response

```