### PR TITLE
Include directions for correctly formatting unfixed CVEs

### DIFF
--- a/cna-handbook.md
+++ b/cna-handbook.md
@@ -129,6 +129,7 @@ This will appear in the issue query linked from https://kubernetes.io/cve.
     * State: `PUBLIC`
     * Assigner: `security@kubernetes.io`
     * Affects: List historical minor versions affected and "prior to 1.x.y" patch versions affected
+      * If a CVE affects all versions, indicate that with a semver range that begins at `0` and ends at `*`
     * Credits: The vulnerability reporter's name
     * Description: `The Kubernetes <component> command/component in versions <affected versions> <vulnerability>`
     * Impact: CVSS impact
@@ -142,7 +143,7 @@ This will appear in the issue query linked from https://kubernetes.io/cve.
     ```bash
     docker run --env-file=env.txt -v ${PWD}/CVE-xxxx-xxxx.json:/tmp/CVE-xxxx-xxxx.json  -it --rm $USER/cvelib:latest publish CVE-xxxx-xxxx  -f /tmp/CVE-xxxx-xxxx.json
     ```
-1. Once the cvelist json file in https://github.com/CVEProject/cvelist is updated, indicate in the [tracking sheet] that the CVE has been populated.
+1. Once the cve has been published via the cve api, indicate in the [tracking sheet] that the CVE has been populated.
 
 ### Reject unused CVEs
 


### PR DESCRIPTION
It was unclear how to properly express a CVE record that affects all versions, or in general that won't be fixed. I filed a helpdesk ticket about this with the CVE project, and the replied with the following.

This PR documents that policy.

`> I am a member of the Kubernetes Security Response Committee and a CNA
> operator. We have a few public CVEs for which no fix has been
> developed, but were erroneously published with fixed-version
> information. I would like to update those records to indicate that all
> versions are affected.
>
> Is there any CNA guidance for what to put in the CVE records for
> unfixed vulnerabilities? Or, can you provide an example of one that is
> well-formed for that situation? (i.e. can I simply publish a record
> with "versions": [ { "status": "affected", "version": "0",
> "versionType": "semver" } ] in it?)

Hello, "all versions are affected" is expressed as a range that begins at '0' and ends at '*'

"versions": [
      {
        "lessThan": "*",
        "status": "affected",
        "version": "0",
        "versionType": "semver"
      }
 ]

- --
CVE Assignment Team
M/S M300, 202 Burlington Road, Bedford, MA 01730 USA`